### PR TITLE
fix ImportError on SQLAlchemy >= 0.7

### DIFF
--- a/zine/application.py
+++ b/zine/application.py
@@ -23,7 +23,7 @@ from babel import Locale
 
 from jinja2 import Environment, BaseLoader, TemplateNotFound
 
-from sqlalchemy.exceptions import SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError
 
 from werkzeug import Request as RequestBase, Response as ResponseBase, \
      SharedDataMiddleware, url_quote, routing, redirect as _redirect, \


### PR DESCRIPTION
Fix ImportError on SQLAlchemy >= 0.7

This updated import also works on older versions of sqlalchemy.
